### PR TITLE
Version 0.1.2

### DIFF
--- a/PlaybackWindow.cpp
+++ b/PlaybackWindow.cpp
@@ -19,6 +19,7 @@
 ***************************************************************************/
 
 #include <stdio.h>
+#include <unistd.h>
 #include <pcap.h>
 #include <pthread.h>
 

--- a/PlaybackWindow.cpp
+++ b/PlaybackWindow.cpp
@@ -644,7 +644,7 @@ PlaybackWindow::onOpen(FXObject *, FXSelector, void*)
 #else
 	// Use the Fox File open dialog.
 	FXFileDialog *dlg = new FXFileDialog(this, "Open PCAP File");
-	dlg->setPatternList("TCPDump Files (*.dump,*.tcpdump,*.pcap)\nAll Files (*)");
+	dlg->setPatternList("TCPDump Files (*.dump,*.tcpdump,*.pcap,*.pcapng)\nAll Files (*)");
 	res = dlg->execute();
 	strncpy(filename, dlg->getFilename().text(), sizeof(filename));
 	filename[sizeof(filename)-1] = '\0';

--- a/README.txt
+++ b/README.txt
@@ -21,7 +21,7 @@ To install the 3rd party dependencies on an Ubuntu system, GCC must first be
 installed. If it has not already been installed, run:
   sudo apt-get install build-essential
 Then run the following:
-  sudo apt-get install libfox-dev libpcap-dev cmake
+  sudo apt-get install libfox-1.6-dev libpcap-dev cmake
 
 To build the software, run the following commands from inside the source
 distribution:

--- a/README.txt
+++ b/README.txt
@@ -30,7 +30,7 @@ distribution:
   sudo make install
 
 Run the software by running the following from the command line:
-  playcap
+  sudo playcap
 
 Mac OS X
 ---------


### PR DESCRIPTION
Updated to compile in latest Linux Mint. libpcap >=1.1.0 supports pcap-nd files. Added .pcapnd file extension to the filter.
